### PR TITLE
Refactor gjs grammar into self-contained definition

### DIFF
--- a/.changeset/proud-pigs-know.md
+++ b/.changeset/proud-pigs-know.md
@@ -1,0 +1,35 @@
+---
+'highlightjs-glimmer': minor
+---
+
+Previously, this package enabled glimmer-js support by patching into the official highlightjs javascript grammar. This is problematic if you want to support both gjs and js(/jsx) syntax highlighting alongside each other.
+
+This change refactors things so that glimmer-javascript is defined and exported as a standalone grammar. Instead of patching the standard javascript grammar, it uses the `subLanguage` feature to extend it cleanly. hbs-literal and template-tag support are added via additional 'contains' rules.
+
+To maintain the existing 'override javascript grammar' behavior for existing consumers of this package, the setup APIs will register `javascript`, `js`, `mjs` and `cjs` as aliases of the new `glimmer-javascript` grammar. Consumers who want to take advantage of the standalone grammar can import it and register using the standard `hljs.registerLanguage` technique.
+
+For example:
+
+```js
+import hljs from 'highlight.js';
+import { glimmerJavascript } from 'highlightjs-glimmer';
+
+hljs.registerLanguage('glimmer-javascript', (hljs) => {
+  const definition = glimmerJavascript(hljs, 'glimmer-javascript');
+
+  return definition;
+});
+```
+
+The old usage, `setup` and other methods,
+
+```js
+import hljs from 'highlight.js';
+import { setup } from 'highlightjs-glimmer';
+
+setup(hljs);
+
+hljs.highlightAll();
+```
+
+Has been unchanged in this release, but is likely to change in a major so that the default / recommended APIs don't take away from the possibility of using other languages in the same document.

--- a/README.md
+++ b/README.md
@@ -103,18 +103,23 @@ highlight();
 
 - `registerLanguage`
 
-    Convenience method for registering the glimmer syntax with
+    Convenience method for registering the glimmer template syntax with
     highlight.js under the name "glimmer"
 
 - `registerInjections`
 
-    Configures injections in supported languages where it's common to use glimmer
-    syntax.
+    Registers the glimmer-javascript grammar, and installes `javascript`, `js`, `mjs` and `cjs`
+    as aliases of it
 
 - `glimmer`
 
-    The highlight.js grammar function. This can be used to register
-    the glimmer grammar under a name other than "glimmer".
+    The highlight.js grammar function for glimmer templates. This can be used to register
+    the glimmer grammar without using the provided setup methods.
+
+- `glimmerJavascript`
+
+    The highlight.js grammar function for glimmer-javascript (gjs) files. This can be used to register
+    the glimmer-javascript grammar without using the provided setup methods.
 
 ## CDN Usage
 

--- a/highlightjs-glimmer/src/glimmer-javascript.js
+++ b/highlightjs-glimmer/src/glimmer-javascript.js
@@ -93,6 +93,7 @@ export default function glimmerJavascript(hljs) {
 
   if (!js) {
     console.warn(`JavaScript grammar not loaded. Cannot initialize glimmerJavascript.`);
+
     return;
   }
 

--- a/highlightjs-glimmer/src/glimmer-javascript.js
+++ b/highlightjs-glimmer/src/glimmer-javascript.js
@@ -88,7 +88,7 @@ const GLIMMER_TEMPLATE_TAG_RULE = {
   ],
 };
 
-export default function glimmerJavascript(hljs, jsLanguageName="javascript") {
+export default function glimmerJavascript(hljs, jsLanguageName = 'javascript') {
   const js = hljs.getLanguage(jsLanguageName);
 
   if (!js) {

--- a/highlightjs-glimmer/src/glimmer-javascript.js
+++ b/highlightjs-glimmer/src/glimmer-javascript.js
@@ -88,8 +88,8 @@ const GLIMMER_TEMPLATE_TAG_RULE = {
   ],
 };
 
-export default function glimmerJavascript(hljs) {
-  let js = hljs.getLanguage('javascript');
+export default function glimmerJavascript(hljs, jsLanguageName="javascript") {
+  const js = hljs.getLanguage(jsLanguageName);
 
   if (!js) {
     console.warn(`JavaScript grammar not loaded. Cannot initialize glimmerJavascript.`);
@@ -100,7 +100,7 @@ export default function glimmerJavascript(hljs) {
   return {
     name: 'glimmer-javascript',
     aliases: ['glimmer-js', 'gjs'],
-    subLanguage: 'javascript',
+    subLanguage: jsLanguageName,
     contains: [GLIMMER_TEMPLATE_TAG_RULE, buildHbsLiteralRule(hljs, js)],
   };
 }

--- a/highlightjs-glimmer/src/glimmer-javascript.js
+++ b/highlightjs-glimmer/src/glimmer-javascript.js
@@ -1,0 +1,105 @@
+function buildHbsLiteralRule(hljs, js) {
+  const rawJs = js.rawDefinition(hljs);
+  const css = rawJs.contains.find((rule) => rule?.begin === 'css`');
+
+  const rule = hljs.inherit(css, { begin: /hbs`/ });
+
+  rule.starts.subLanguage = 'glimmer';
+
+  return rule;
+}
+
+/**
+ * A lot of this is stolen from XML
+ */
+const GLIMMER_TEMPLATE_TAG = {
+  begin: /<template>/,
+  end: /<\/template>/,
+  /**
+   * @param {RegExpMatchArray} match
+   * @param {CallbackResponse} response
+   */
+  isTrulyOpeningTag: (match, response) => {
+    const afterMatchIndex = match[0].length + match.index;
+    const nextChar = match.input[afterMatchIndex];
+
+    if (
+      // HTML should not include another raw `<` inside a tag
+      // nested type?
+      // `<Array<Array<number>>`, etc.
+      nextChar === '<' ||
+      // the , gives away that this is not HTML
+      // `<T, A extends keyof T, V>`
+      nextChar === ','
+    ) {
+      response.ignoreMatch();
+
+      return;
+    }
+
+    // `<something>`
+    // Quite possibly a tag, lets look for a matching closing tag...
+    // if (nextChar === '>') {
+    //   // if we cannot find a matching closing tag, then we
+    //   // will ignore it
+    //   if (!hasClosingTag(match, { after: afterMatchIndex })) {
+    //     response.ignoreMatch();
+    //   }
+    // }
+
+    // `<blah />` (self-closing)
+    // handled by simpleSelfClosing rule
+
+    // `<From extends string>`
+    // technically this could be HTML, but it smells like a type
+    let m;
+    const afterMatch = match.input.substring(afterMatchIndex);
+
+    // NOTE: This is ugh, but added specifically for https://github.com/highlightjs/highlight.js/issues/3276
+    if ((m = afterMatch.match(/^\s+extends\s+/))) {
+      if (m.index === 0) {
+        response.ignoreMatch();
+
+        // eslint-disable-next-line no-useless-return
+        return;
+      }
+    }
+  },
+};
+
+const GLIMMER_TEMPLATE_TAG_RULE = {
+  variants: [
+    {
+      begin: GLIMMER_TEMPLATE_TAG.begin,
+      // we carefully check the opening tag to see if it truly
+      // is a tag and not a false positive
+      'on:begin': GLIMMER_TEMPLATE_TAG.isTrulyOpeningTag,
+      end: GLIMMER_TEMPLATE_TAG.end,
+    },
+  ],
+  subLanguage: 'glimmer',
+  contains: [
+    {
+      begin: GLIMMER_TEMPLATE_TAG.begin,
+      end: GLIMMER_TEMPLATE_TAG.end,
+      skip: true,
+      contains: ['self'],
+    },
+  ],
+};
+
+export default function glimmerJavascript(hljs) {
+  let js = hljs.getLanguage('javascript');
+
+  if (!js) {
+    console.warn(`JavaScript grammar not loaded. Cannot initialize glimmerJavascript.`);
+    return;
+  }
+
+  return {
+    name: 'glimmer-javascript',
+    aliases: ['glimmer-js', 'gjs'],
+    subLanguage: 'javascript',
+    contains: [GLIMMER_TEMPLATE_TAG_RULE, buildHbsLiteralRule(hljs, js)],
+  };
+}

--- a/highlightjs-glimmer/src/index.js
+++ b/highlightjs-glimmer/src/index.js
@@ -39,16 +39,19 @@ export function registerInjections(hljs) {
 }
 
 function registerGlimmerJsWithJsOverrides(hljs) {
-  const newJsLanguageName = "_js-in-gjs";
+  const newJsLanguageName = '_js-in-gjs';
 
   // Rename original language so that we can still use it
   let js = hljs.getLanguage('javascript');
+
   hljs.registerLanguage(newJsLanguageName, (hljs) => js.rawDefinition(hljs));
-  hljs.unregisterLanguage("javascript");
+  hljs.unregisterLanguage('javascript');
 
   hljs.registerLanguage('glimmer-javascript', (hljs) => {
     const definition = glimmerJavascript(hljs, newJsLanguageName);
+
     definition.aliases.push('javascript', 'js', 'mjs', 'cjs', 'mjs');
+
     return definition;
   });
 }

--- a/highlightjs-glimmer/src/index.js
+++ b/highlightjs-glimmer/src/index.js
@@ -39,11 +39,16 @@ export function registerInjections(hljs) {
 }
 
 function registerGlimmerJsWithJsOverrides(hljs) {
+  const newJsLanguageName = "_js-in-gjs";
+
+  // Rename original language so that we can still use it
+  let js = hljs.getLanguage('javascript');
+  hljs.registerLanguage(newJsLanguageName, (hljs) => js.rawDefinition(hljs));
+  hljs.unregisterLanguage("javascript");
+
   hljs.registerLanguage('glimmer-javascript', (hljs) => {
-    const definition = glimmerJavascript(hljs);
-
-    definition.aliases.push('javascript', 'js', 'mjs', 'cjs');
-
+    const definition = glimmerJavascript(hljs, newJsLanguageName);
+    definition.aliases.push('javascript', 'js', 'mjs', 'cjs', 'mjs');
     return definition;
   });
 }

--- a/highlightjs-glimmer/src/index.js
+++ b/highlightjs-glimmer/src/index.js
@@ -1,7 +1,14 @@
 import _glimmer from './glimmer.js';
+import _glimmerJavascript from './glimmer-javascript.js';
 
 export const glimmer = _glimmer;
+export const glimmerJavascript = _glimmerJavascript;
 
+/**
+ * The convenience method for configuring everything related to
+ * glimmer highlighting. This wraps `registerLanguage` and `registerInjections`.
+ * For most use cases, this should be the only method you need.
+ */
 export function setup(hljs) {
   registerLanguage(hljs);
   registerInjections(hljs);
@@ -15,129 +22,26 @@ export function externalSetup(hljs) {
   return grammar;
 }
 
+/**
+ * Convenience method for registering the glimmer template syntax with
+ * highlight.js under the name "glimmer"
+ */
 export function registerLanguage(hljs) {
   return hljs.registerLanguage('glimmer', _glimmer);
 }
 
-export function registerInjections(hljs) {
-  registerJavaScriptInjections(hljs);
-}
-
-function registerJavaScriptInjections(hljs) {
-  let js = hljs.getLanguage('javascript');
-
-  if (!js) {
-    console.warn(`JavaScript grammar not loaded`);
-
-    return;
-  }
-
-  js = js.rawDefinition(hljs);
-
-  setupHBSLiteral(hljs, js);
-  swapXMLForGlimmer(hljs, js);
-  setupTemplateTag(hljs, js);
-
-  hljs.registerLanguage('javascript', () => js);
-  hljs.registerLanguage('glimmer-javascript', () => js);
-}
-
-function setupHBSLiteral(hljs, js) {
-  let cssIndex = js.contains.findIndex((rule) => rule?.begin === 'css`');
-  let css = js.contains[cssIndex];
-
-  const HBS_TEMPLATE = hljs.inherit(css, { begin: /hbs`/ });
-
-  HBS_TEMPLATE.starts.subLanguage = 'glimmer';
-
-  js.contains.splice(cssIndex, 0, HBS_TEMPLATE);
-}
-
-function swapXMLForGlimmer(_hljs, js) {
-  // The default JSX grammar is actually just XML, which... is also wrong :D
-  js.contains
-    .flatMap((contains) => contains?.contains || contains)
-    .filter((rule) => rule.subLanguage === 'xml')
-    .forEach((rule) => (rule.subLanguage = 'glimmer'));
-}
-
 /**
- * A lot of this is stolen from XML
+ * Registers the glimmer-javascript grammar, and installes `javascript`,
+ * `js`, `mjs` and `cjs` as aliases of it
  */
-function setupTemplateTag(_hljs, js) {
-  const GLIMMER_TEMPLATE_TAG = {
-    begin: /<template>/,
-    end: /<\/template>/,
-    /**
-     * @param {RegExpMatchArray} match
-     * @param {CallbackResponse} response
-     */
-    isTrulyOpeningTag: (match, response) => {
-      const afterMatchIndex = match[0].length + match.index;
-      const nextChar = match.input[afterMatchIndex];
+export function registerInjections(hljs) {
+  registerGlimmerJsWithJsOverrides(hljs);
+}
 
-      if (
-        // HTML should not include another raw `<` inside a tag
-        // nested type?
-        // `<Array<Array<number>>`, etc.
-        nextChar === '<' ||
-        // the , gives away that this is not HTML
-        // `<T, A extends keyof T, V>`
-        nextChar === ','
-      ) {
-        response.ignoreMatch();
-
-        return;
-      }
-
-      // `<something>`
-      // Quite possibly a tag, lets look for a matching closing tag...
-      // if (nextChar === '>') {
-      //   // if we cannot find a matching closing tag, then we
-      //   // will ignore it
-      //   if (!hasClosingTag(match, { after: afterMatchIndex })) {
-      //     response.ignoreMatch();
-      //   }
-      // }
-
-      // `<blah />` (self-closing)
-      // handled by simpleSelfClosing rule
-
-      // `<From extends string>`
-      // technically this could be HTML, but it smells like a type
-      let m;
-      const afterMatch = match.input.substring(afterMatchIndex);
-
-      // NOTE: This is ugh, but added specifically for https://github.com/highlightjs/highlight.js/issues/3276
-      if ((m = afterMatch.match(/^\s+extends\s+/))) {
-        if (m.index === 0) {
-          response.ignoreMatch();
-
-          // eslint-disable-next-line no-useless-return
-          return;
-        }
-      }
-    },
-  };
-
-  js.contains.unshift({
-    variants: [
-      {
-        begin: GLIMMER_TEMPLATE_TAG.begin,
-        // we carefully check the opening tag to see if it truly
-        // is a tag and not a false positive
-        'on:begin': GLIMMER_TEMPLATE_TAG.isTrulyOpeningTag,
-        end: GLIMMER_TEMPLATE_TAG.end,
-      },
-    ],
-    subLanguage: 'glimmer',
-    contains: [
-      {
-        begin: GLIMMER_TEMPLATE_TAG.begin,
-        end: GLIMMER_TEMPLATE_TAG.end,
-        skip: true,
-        contains: ['self'],
-      },
-    ],
+function registerGlimmerJsWithJsOverrides(hljs) {
+  hljs.registerLanguage('glimmer-javascript', (hljs) => {
+    const definition = glimmerJavascript(hljs);
+    definition.aliases.push('javascript', 'js', 'mjs', 'cjs');
+    return definition;
   });
 }

--- a/highlightjs-glimmer/src/index.js
+++ b/highlightjs-glimmer/src/index.js
@@ -41,7 +41,9 @@ export function registerInjections(hljs) {
 function registerGlimmerJsWithJsOverrides(hljs) {
   hljs.registerLanguage('glimmer-javascript', (hljs) => {
     const definition = glimmerJavascript(hljs);
+
     definition.aliases.push('javascript', 'js', 'mjs', 'cjs');
+
     return definition;
   });
 }

--- a/tests-esm/unit/__snapshots__/injections.test.js.snap
+++ b/tests-esm/unit/__snapshots__/injections.test.js.snap
@@ -13,67 +13,68 @@ setTimeout(() <span class=\\"hljs-operator\\">=</span>&gt; {
 `;
 
 exports[`Injections | JS > gjs / template tag > is embedded in a class 1`] = `
-"<span class=\\"hljs-keyword\\">import</span>
-<span class=\\"hljs-title class_\\">Component</span>
-<span class=\\"hljs-keyword\\">from</span>
-<span class=\\"hljs-string\\">&#x27;@glimmer/component&#x27;</span>
-;
-<span class=\\"hljs-keyword\\">import</span>
-{ gt, lt }
-<span class=\\"hljs-keyword\\">from</span>
-<span class=\\"hljs-string\\">&#x27;@glimmer/helper&#x27;</span>
-;
+"<span class=\\"language-_js-in-gjs\\">
+  <span class=\\"hljs-keyword\\">import</span>
+  <span class=\\"hljs-title class_\\">Component</span>
+  <span class=\\"hljs-keyword\\">from</span>
+  <span class=\\"hljs-string\\">&#x27;@glimmer/component&#x27;</span>
+  ;
+  <span class=\\"hljs-keyword\\">import</span>
+  { gt, lt }
+  <span class=\\"hljs-keyword\\">from</span>
+  <span class=\\"hljs-string\\">&#x27;@glimmer/helper&#x27;</span>
+  ;
 
-<span class=\\"hljs-keyword\\">export</span>
-<span class=\\"hljs-keyword\\">default</span>
-<span class=\\"hljs-keyword\\">class</span>
-<span class=\\"hljs-title class_\\">WeatherSummary</span>
-<span class=\\"hljs-keyword\\">extends</span>
-<span class=\\"hljs-title class_ inherited__\\">Component</span>
-{ @tracked currentTemp; interval; getWeather =
-<span class=\\"hljs-function\\">() =&gt;</span>
-{
-<span class=\\"hljs-variable language_\\">this</span>
-.
-<span class=\\"hljs-property\\">currentTemp</span>
-=
-<span class=\\"hljs-comment\\">// something</span>
-}
+  <span class=\\"hljs-keyword\\">export</span>
+  <span class=\\"hljs-keyword\\">default</span>
+  <span class=\\"hljs-keyword\\">class</span>
+  <span class=\\"hljs-title class_\\">WeatherSummary</span>
+  <span class=\\"hljs-keyword\\">extends</span>
+  <span class=\\"hljs-title class_ inherited__\\">Component</span>
+  { @tracked currentTemp; interval; getWeather =
+  <span class=\\"hljs-function\\">() =&gt;</span>
+  {
+  <span class=\\"hljs-variable language_\\">this</span>
+  .
+  <span class=\\"hljs-property\\">currentTemp</span>
+  =
+  <span class=\\"hljs-comment\\">// something</span>
+  }
 
-<span class=\\"hljs-title function_\\">constructor</span>
-(
-<span class=\\"hljs-params\\">owner, args</span>
-) {
-<span class=\\"hljs-variable language_\\">super</span>
-(owner, args);
-<span class=\\"hljs-variable language_\\">this</span>
-.
-<span class=\\"hljs-property\\">interval</span>
-=
-<span class=\\"hljs-built_in\\">setInterval</span>
-(
-<span class=\\"hljs-variable language_\\">this</span>
-.
-<span class=\\"hljs-property\\">getWeather</span>
-,
-<span class=\\"hljs-number\\">10000</span>
-); }
+  <span class=\\"hljs-title function_\\">constructor</span>
+  (
+  <span class=\\"hljs-params\\">owner, args</span>
+  ) {
+  <span class=\\"hljs-variable language_\\">super</span>
+  (owner, args);
+  <span class=\\"hljs-variable language_\\">this</span>
+  .
+  <span class=\\"hljs-property\\">interval</span>
+  =
+  <span class=\\"hljs-built_in\\">setInterval</span>
+  (
+  <span class=\\"hljs-variable language_\\">this</span>
+  .
+  <span class=\\"hljs-property\\">getWeather</span>
+  ,
+  <span class=\\"hljs-number\\">10000</span>
+  ); }
 
-<span class=\\"hljs-title function_\\">willDestroy</span>
-(
-<span class=\\"hljs-params\\"></span>
-) {
-<span class=\\"hljs-variable language_\\">super</span>
-.
-<span class=\\"hljs-title function_\\">willDestroy</span>
-();
-<span class=\\"hljs-built_in\\">clearInterval</span>
-(
-<span class=\\"hljs-variable language_\\">this</span>
-.
-<span class=\\"hljs-property\\">interval</span>
-); }
-
+  <span class=\\"hljs-title function_\\">willDestroy</span>
+  (
+  <span class=\\"hljs-params\\"></span>
+  ) {
+  <span class=\\"hljs-variable language_\\">super</span>
+  .
+  <span class=\\"hljs-title function_\\">willDestroy</span>
+  ();
+  <span class=\\"hljs-built_in\\">clearInterval</span>
+  (
+  <span class=\\"hljs-variable language_\\">this</span>
+  .
+  <span class=\\"hljs-property\\">interval</span>
+  ); }
+</span>
 <span class=\\"language-glimmer\\">
   <span class=\\"hljs-tag\\">
     &lt;
@@ -135,20 +136,22 @@ exports[`Injections | JS > gjs / template tag > is embedded in a class 1`] = `
     &gt;
   </span>
 </span>
-}
+<span class=\\"language-_js-in-gjs\\">}</span>
 "
 `;
 
 exports[`Injections | JS > gjs / template tag > multiple components 1`] = `
-"<span class=\\"hljs-keyword\\">import</span>
-<span class=\\"hljs-title class_\\">WeatherSummary</span>
-<span class=\\"hljs-keyword\\">from</span>
-<span class=\\"hljs-string\\">&#x27;./weather-summary.js&#x27;</span>
-;
+"<span class=\\"language-_js-in-gjs\\">
+  <span class=\\"hljs-keyword\\">import</span>
+  <span class=\\"hljs-title class_\\">WeatherSummary</span>
+  <span class=\\"hljs-keyword\\">from</span>
+  <span class=\\"hljs-string\\">&#x27;./weather-summary.js&#x27;</span>
+  ;
 
-<span class=\\"hljs-keyword\\">const</span>
-<span class=\\"hljs-title class_\\">Greeting</span>
-=
+  <span class=\\"hljs-keyword\\">const</span>
+  <span class=\\"hljs-title class_\\">Greeting</span>
+  =
+</span>
 <span class=\\"language-glimmer\\">
   <span class=\\"hljs-tag\\">
     &lt;
@@ -179,29 +182,30 @@ exports[`Injections | JS > gjs / template tag > multiple components 1`] = `
     &gt;
   </span>
 </span>
-;
+<span class=\\"language-_js-in-gjs\\">
+  ;
 
-<span class=\\"hljs-keyword\\">function</span>
-<span class=\\"hljs-title function_\\">isBirthday</span>
-(
-<span class=\\"hljs-params\\">dateOfBirth</span>
-) {
-<span class=\\"hljs-keyword\\">const</span>
-now =
-<span class=\\"hljs-keyword\\">new</span>
-<span class=\\"hljs-title class_\\">Date</span>
-();
-<span class=\\"hljs-keyword\\">return</span>
-( dateOfBirth.
-<span class=\\"hljs-title function_\\">getDate</span>
-() === now.
-<span class=\\"hljs-title function_\\">getDate</span>
-() &amp;&amp; dateOfBirth.
-<span class=\\"hljs-title function_\\">getMonth</span>
-() === now.
-<span class=\\"hljs-title function_\\">getMonth</span>
-() ); }
-
+  <span class=\\"hljs-keyword\\">function</span>
+  <span class=\\"hljs-title function_\\">isBirthday</span>
+  (
+  <span class=\\"hljs-params\\">dateOfBirth</span>
+  ) {
+  <span class=\\"hljs-keyword\\">const</span>
+  now =
+  <span class=\\"hljs-keyword\\">new</span>
+  <span class=\\"hljs-title class_\\">Date</span>
+  ();
+  <span class=\\"hljs-keyword\\">return</span>
+  ( dateOfBirth.
+  <span class=\\"hljs-title function_\\">getDate</span>
+  () === now.
+  <span class=\\"hljs-title function_\\">getDate</span>
+  () &amp;&amp; dateOfBirth.
+  <span class=\\"hljs-title function_\\">getMonth</span>
+  () === now.
+  <span class=\\"hljs-title function_\\">getMonth</span>
+  () ); }
+</span>
 <span class=\\"language-glimmer\\">
   <span class=\\"hljs-tag\\">
     &lt;

--- a/tests-esm/unit/injections.test.js
+++ b/tests-esm/unit/injections.test.js
@@ -14,7 +14,7 @@ describe('Injections | JS', () => {
       );
 
       expect(result).toEqual(
-        '<span class="hljs-keyword">const</span> hbs`<span class="language-glimmer"><span class="hljs-punctuation mustache">{{<span class="hljs-title">foo</span>}}</span>`</span>'
+        '<span class="language-_js-in-gjs"><span class="hljs-keyword">const</span> </span>hbs`<span class="language-glimmer"><span class="hljs-punctuation mustache">{{<span class="hljs-title">foo</span>}}</span>`</span>'
       );
     });
   });
@@ -32,14 +32,16 @@ describe('Injections | JS', () => {
 
       expect(result).toEqual(
         list(
+          '<span class="language-_js-in-gjs">',
           tags.keyword.export,
           ' ',
           tags.keyword.const,
           ' ',
           tag('title class_', 'Name'),
           ' = ',
+          '</span>',
           glimmer(template(tags.mustache(tags.arg('name')))),
-          ';'
+          '<span class="language-_js-in-gjs">;</span>'
         )
       );
     });
@@ -69,10 +71,12 @@ describe('Injections | JS', () => {
 
       expect(result).toEqual(
         list(
+          '<span class="language-_js-in-gjs">',
           tags.keyword.export,
           ' ',
           tags.keyword.default,
           ' ',
+          '</span>',
           glimmer(template(tags.mustache(tags.arg('name'))))
         )
       );
@@ -98,10 +102,9 @@ describe('Injections | JS', () => {
         result,
         list(
           // These are JS and not tagged by us
-          `<span class="hljs-keyword">import</span> <span class="hljs-title class_">Greeting</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./greeting.js&#x27;</span>;`,
+          `<span class="language-_js-in-gjs"><span class="hljs-keyword">import</span> <span class="hljs-title class_">Greeting</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./greeting.js&#x27;</span>;`,
           '\n',
-          `<span class="hljs-keyword">import</span> <span class="hljs-title class_">WeatherSummary</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./weather-summary.js&#x27;</span>;`,
-          '\n',
+          `<span class="hljs-keyword">import</span> <span class="hljs-title class_">WeatherSummary</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./weather-summary.js&#x27;</span>;</span>`,
           '\n',
           glimmer(
             template(
@@ -170,7 +173,7 @@ describe('Injections | JS', () => {
         result,
         list(
           // These are JS and not tagged by us
-          `<span class="hljs-keyword">import</span> <span class="hljs-title class_">Greeting</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./greeting.js&#x27;</span>;
+          `<span class="language-_js-in-gjs"><span class="hljs-keyword">import</span> <span class="hljs-title class_">Greeting</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./greeting.js&#x27;</span>;
  <span class="hljs-keyword">import</span> <span class="hljs-title class_">WeatherSummary</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;./weather-summary.js&#x27;</span>;
 
  <span class="hljs-keyword">function</span> <span class="hljs-title function_">isBirthday</span>(<span class="hljs-params">dateOfBirth</span>) {
@@ -182,6 +185,7 @@ describe('Injections | JS', () => {
  }`,
           '\n',
           '\n',
+          '</span>',
           glimmer(
             template(
               tags.element('div', [


### PR DESCRIPTION
Previously, this package enabled glimmer-js support by patching into the official highlightjs javascript grammar. This is problematic if you want to support both gjs and js(/jsx) syntax highlighting alongside each other.

This commit refactors things so that glimmer-javascript is defined and exported as a standalone grammar. Instead of patching the standard javascript grammar, it uses the `subLanguage` feature to extend it cleanly. hbs-literal and template-tag support are added via additional 'contains' rules.

To maintain the existing 'override javascript grammar' behavior for existing consumers of this package, the setup APIs will register  `javascript`, `js`, `mjs` and `cjs` as aliases of the new `glimmer-javascript` grammar. Consumers who want to take advantage of the standalone grammar can import it and register using the standard `hljs.registerLanguage` technique.

In future, it may be beneficial to deprecate the custom setup functions and recommend use of the standard `registerLanguage` technique. But for now, this commit leaves all existing public API unchanged.