### PR TITLE
Fix compatibility with highlight-js 11.10.0

### DIFF
--- a/.changeset/calm-bottles-smoke.md
+++ b/.changeset/calm-bottles-smoke.md
@@ -1,0 +1,5 @@
+---
+'highlightjs-glimmer': patch
+---
+
+Fix compatibility with highlight-js 11.10.0

--- a/highlightjs-glimmer/src/glimmer-javascript.js
+++ b/highlightjs-glimmer/src/glimmer-javascript.js
@@ -1,6 +1,11 @@
+const CSS_RULE_BEGIN = [
+  'css`', // hljs <= 11.9.0
+  '.?css`', // hljs >= 11.10.0
+];
+
 function buildHbsLiteralRule(hljs, js) {
   const rawJs = js.rawDefinition(hljs);
-  const css = rawJs.contains.find((rule) => rule?.begin === 'css`');
+  const css = rawJs.contains.find((rule) => CSS_RULE_BEGIN.includes(rule?.begin));
 
   const rule = hljs.inherit(css, { begin: /hbs`/ });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^8.55.0
         version: 8.56.0
       highlight.js:
-        specifier: ^11.9.0
-        version: 11.9.0
+        specifier: ^11.10.0
+        version: 11.10.0
       markdown-it:
         specifier: ^14.0.0
         version: 14.0.0
@@ -167,8 +167,8 @@ importers:
         specifier: ^8.55.0
         version: 8.56.0
       highlight.js:
-        specifier: '>= 11.9.0'
-        version: 11.9.0
+        specifier: '>= 11.10.0'
+        version: 11.10.0
       markdown-it:
         specifier: ^14.0.0
         version: 14.0.0
@@ -4929,6 +4929,11 @@ packages:
 
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    dev: true
+
+  /highlight.js@11.10.0:
+    resolution: {integrity: sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /highlight.js@11.8.0:

--- a/tests-cjs/package.json
+++ b/tests-cjs/package.json
@@ -19,7 +19,7 @@
     "common-tags": "^1.8.2",
     "concurrently": "^8.2.2",
     "eslint": "^8.55.0",
-    "highlight.js": "^11.9.0",
+    "highlight.js": "^11.10.0",
     "markdown-it": "^14.0.0",
     "prettier": "^2.8.8",
     "rehype-highlight": "^6.0.0",

--- a/tests-esm/package.json
+++ b/tests-esm/package.json
@@ -23,7 +23,7 @@
     "common-tags": "^1.8.2",
     "concurrently": "^8.2.2",
     "eslint": "^8.55.0",
-    "highlight.js": ">= 11.9.0",
+    "highlight.js": ">= 11.10.0",
     "markdown-it": "^14.0.0",
     "prettier": "^2.8.8",
     "rehype": "^12.0.1",


### PR DESCRIPTION
The change in https://github.com/highlightjs/highlight.js/commit/c81367431ab132f37cbc2103adc1ff6b21784863 affected our detection of the css rule, which is used as a base for the `hbs` tagged-template-literal highlighting.